### PR TITLE
Fix bug 916

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -11,11 +11,17 @@
 
     <p>PySide is built using the <a href="http://www.pyside.org/docs/shiboken">Shiboken</a> binding generator.</p>
 
-  <h2>Modules</h2>
+  <h2>Notes</h2>
 
-  <div class="admonition warning">
-  <strong>Note:</strong> The PySide class reference documentation is automatically generated from the original Qt documentation for C++, some parts were tuned to fit the Python world, however is not possible to rewrite all Qt docs as it would require a really huge effort, so if the documentation says you can use 0 on an QObject argument, interpret it as None.
-  </div>
+    <h3>About 0 vs None</h3>
+
+    <p>The PySide class reference documentation is automatically generated from the original Qt documentation for C++, some parts were tuned to fit the Python world, however is not possible to rewrite all Qt docs as it would require a really huge effort, so if the documentation says you can use 0 on an QObject argument, interpret it as None.</p>
+
+    <h3>About keyword arguments</h3>
+
+    <p>Only optional arguments can be used as keyword arguments.</p>
+
+  <h2>Modules</h2>
 
   <table class="contentstable" align="center" ><tr>
     <td width="50%">


### PR DESCRIPTION
Fix bug 916 - "Missing info about when is possible to use keyword arguments in docs [was: QListWidgetItem's constructor ignores text parameter]"
