### PR TITLE
Fixes bug #910 - installEventFilter() increments reference count on target object.

### DIFF
--- a/PySide/QtCore/typesystem_core.xml
+++ b/PySide/QtCore/typesystem_core.xml
@@ -1284,16 +1284,6 @@
         <define-ownership owner="c++"/>
       </modify-argument>
     </modify-function>
-    <modify-function signature="installEventFilter(QObject*)">
-      <inject-code>
-        Shiboken::Object::keepReference((SbkObject*)%PYARG_1, "eventFilter", %PYSELF, true);
-      </inject-code>
-    </modify-function>
-    <modify-function signature="removeEventFilter(QObject*)">
-      <inject-code>
-        Shiboken::Object::removeReference((SbkObject*)%PYARG_1, "eventFilter", %PYSELF);
-      </inject-code>
-    </modify-function>
     <!-- Invalidate-after-use stuff -->
     <modify-function signature="childEvent(QChildEvent*)">
         <modify-argument index="1" invalidate-after-use="yes"/>

--- a/tests/QtGui/event_filter_test.py
+++ b/tests/QtGui/event_filter_test.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 
 from helper import UsesQApplication
-from PySide.QtCore import QObject, QEvent, QTimer
+from PySide.QtCore import QObject, QEvent
 from PySide.QtGui import QWidget
 
 class MyFilter(QObject):
@@ -17,10 +17,10 @@ class EventFilter(UsesQApplication):
         o = QObject()
         filt = MyFilter()
         o.installEventFilter(filt)
-        self.assertEqual(sys.getrefcount(o), 3)
+        self.assertEqual(sys.getrefcount(o), 2)
 
         o.installEventFilter(filt)
-        self.assertEqual(sys.getrefcount(o), 3)
+        self.assertEqual(sys.getrefcount(o), 2)
 
         o.removeEventFilter(filt)
         self.assertEqual(sys.getrefcount(o), 2)


### PR DESCRIPTION
Fixes bug #910 - installEventFilter() increments reference count on target object.

http://bugs.pyside.org/show_bug.cgi?id=910

Also added/fixed unit tests.
