### PR TITLE
Fix segfault when accessing "signal[None]"

### DIFF
--- a/libpyside/pysidesignal.cpp
+++ b/libpyside/pysidesignal.cpp
@@ -585,10 +585,10 @@ char* getTypeName(PyObject* type)
                 typeName = strdup("PyObject");
         }
         return typeName;
+    } else if (type == Py_None) { // Must be checked before as Shiboken::String::check accepts Py_None
+        return strdup("void");
     } else if (Shiboken::String::check(type)) {
         return strdup(Shiboken::String::toCString(type));
-    } else if (type == Py_None) {
-        return strdup("void");
     }
     return 0;
 }


### PR DESCRIPTION
Was segfaulting for signals with None as an explicit
argument (returning NULL to a strdup).
