### PR TITLE
Fixed compilation error for gcc versions < 4

### DIFF
--- a/libpyside/pysidemacros.h
+++ b/libpyside/pysidemacros.h
@@ -40,7 +40,7 @@
         #define PYSIDE_DEPRECATED(func) func __attribute__ ((deprecated))
     #else
         #define PYSIDE_API
-        #define DEPRECATED(func) func
+        #define PYSIDE_DEPRECATED(func) func
     #endif
 #endif
 


### PR DESCRIPTION
Similar issue as reported in https://github.com/PySide/Apiextractor/pull/17 and https://github.com/PySide/Generatorrunner/pull/16 - PYSIDE_DEPRECATED was missing here
